### PR TITLE
Add prompt autocomplete test

### DIFF
--- a/cmd/prompt/prompt_test.go
+++ b/cmd/prompt/prompt_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +25,12 @@ func TestPromptCommand_FlagsRegistered(t *testing.T) {
 	assert.NotNil(t, flags.Lookup("config"))
 	assert.NotNil(t, flags.Lookup("output"))
 	assert.NotNil(t, flags.Lookup("preview"))
+}
+
+func TestPromptAutoComplete_ReturnsCategories(t *testing.T) {
+	completions, directive := promptAutoComplete(&cobra.Command{}, nil, "")
+
+	expected := []string{"topics", "demo", "classification"}
+	assert.Equal(t, expected, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }


### PR DESCRIPTION
## Summary
- add cobra import in prompt tests
- add TestPromptAutoComplete_ReturnsCategories to ensure autocomplete behavior

## Testing
- `go test ./...` *(fails: download go1.24.1: no route to host)*
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.1)*
