### PR TITLE
Fix output write path handling

### DIFF
--- a/cmd/llm/helper.go
+++ b/cmd/llm/helper.go
@@ -3,6 +3,8 @@ package llm
 import (
 	"fmt"
 	"os"
+
+	"raja.aiml/ai.explorer/paths"
 )
 
 // getPrompt reads the prompt from a file and returns its content as a string.
@@ -16,5 +18,6 @@ func getPrompt(path string) (string, error) {
 
 // saveResponse writes the LLM response to the specified file.
 func saveResponse(response, path string) error {
+	paths.EnsureDirectoryExists(path)
 	return os.WriteFile(path, []byte(response), 0644)
 }

--- a/prompt/builder.go
+++ b/prompt/builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flosch/pongo2/v6"
 	"gopkg.in/yaml.v3"
 	"raja.aiml/ai.explorer/logger"
+	"raja.aiml/ai.explorer/paths"
 )
 
 // Builder implements the Renderer interface using pongo2 and YAML config.
@@ -76,6 +77,7 @@ func (b *Builder) renderAndWrite(tpl *pongo2.Template, ctx pongo2.Context, outPa
 	if err != nil {
 		b.Logger.Fatalf("template rendering failed: %v", err)
 	}
+	paths.EnsureDirectoryExists(outPath)
 	if err := b.WriteFile(outPath, []byte(out), 0644); err != nil {
 		b.Logger.Fatalf("failed to write output file: %v", err)
 	}


### PR DESCRIPTION
## Summary
- create directories before saving LLM responses
- create directories before writing rendered prompts

## Testing
- `gofmt -w cmd/llm/helper.go prompt/builder.go`
- ❌ `go test ./...` *(fails: go.mod requires go >= 1.24.1)*