### PR TITLE
Fix docs, bug, comment, and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - 🧠 **Prompt Generator**: Generate prompts using YAML config + template.
 - 🤖 **LLM CLI**: Send raw prompts to LLMs (e.g., OpenAI, Ollama).
-- 🛠️ **Template System**: Uses `pongo2` (Jinja-like) templating.
+- 🛠 **Taskfile automation**: handy build & test tasks
 - 📁 **Category-based routing**: Organize prompts under `resources/<category>/<topic>`.
 - ✅ **100% Unit + E2E Tests**: Ginkgo-powered full coverage.
 - 📜 **Shell Completion**: Autogenerate completions for bash, zsh, fish, PowerShell.

--- a/cmd/llm/runner.go
+++ b/cmd/llm/runner.go
@@ -17,7 +17,6 @@ type LLMRunner struct {
 }
 
 // Run executes the LLM flow.
-// Run executes the LLM flow.
 func (r *LLMRunner) Run() {
 	fmt.Fprintln(r.Out, "[llm] Reading prompt...")
 	prompt, err := r.GetPrompt(r.PromptPath)

--- a/cmd/prompt/autocomplete_test.go
+++ b/cmd/prompt/autocomplete_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPromptAutoComplete(t *testing.T) {
+	cmd := &cobra.Command{}
+	completions, directive := promptAutoComplete(cmd, []string{}, "")
+
+	expected := []string{"topics", "demo", "classification"}
+	assert.Equal(t, expected, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}

--- a/resources/demo/hello/prompt.txt
+++ b/resources/demo/hello/prompt.txt
@@ -1,0 +1,1 @@
+Hello, AI Explorer!


### PR DESCRIPTION
## Summary
- clarify README feature list
- remove duplicate comment in LLM runner
- add missing default prompt file for `llm` command
- cover prompt autocomplete in tests

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.1)*